### PR TITLE
[Proposal] Configure health check to work with Istio Auth

### DIFF
--- a/client-service-consumer/src/main/fabric8/deployment.yml
+++ b/client-service-consumer/src/main/fabric8/deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - livenessProbe:
+          failureThreshold: 2
+          initialDelaySeconds: 60
+          periodSeconds: 3
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health

--- a/service-a/src/main/fabric8/dc.yml
+++ b/service-a/src/main/fabric8/dc.yml
@@ -17,6 +17,26 @@ spec:
       - image: service-a:latest
         imagePullPolicy: Always
         name: spring-boot
+        livenessProbe:
+          failureThreshold: 2
+          initialDelaySeconds: 60
+          periodSeconds: 3
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
   triggers:
   - imageChangeParams:
       automatic: true

--- a/service-b/src/main/fabric8/dc.yml
+++ b/service-b/src/main/fabric8/dc.yml
@@ -17,6 +17,26 @@ spec:
       - image: service-b:latest
         imagePullPolicy: Always
         name: spring-boot
+        livenessProbe:
+          failureThreshold: 2
+          initialDelaySeconds: 60
+          periodSeconds: 3
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
   triggers:
   - imageChangeParams:
       automatic: true


### PR DESCRIPTION
I've tried to run this booster on a cluster with Istio Auth enabled and it's health checks kept failing. I suggest we adapt all the health check configurations to work with and without Istio Auth.