### PR TITLE
Ensure that the load balancing rules work in any Istio cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <spring-boot-bom.version>1.5.16.SP1</spring-boot-bom.version>
     <spring-boot.version>1.5.16.RELEASE</spring-boot.version>
     <rest-assured.version>3.1.0</rest-assured.version>
-    <arquillian-cube.version>1.17.1</arquillian-cube.version>
+    <arquillian-cube.version>1.18.0</arquillian-cube.version>
     <arquillian-junit.version>1.4.0.Final</arquillian-junit.version>
     <mksapi.version>4.10.9049</mksapi.version>
 

--- a/rules/load-balancing-rule.yml
+++ b/rules/load-balancing-rule.yml
@@ -1,9 +1,25 @@
+# We add the policy to disable TLS in order to ensure that
+# we can always use the same value of DISABLE in the
+# DestinationRule
+# This is only done to ensure that the booster works flawlessly in
+# an Istio environment whether TLS is globally enabled or not
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: spring-boot-istio-routing-service
+spec:
+  targets:
+  - name: spring-boot-istio-routing-service
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: spring-boot-istio-routing-service
 spec:
   host: spring-boot-istio-routing-service
+  trafficPolicy:
+    tls:
+      mode: DISABLE
   subsets:
   - name: a
     labels:


### PR DESCRIPTION
What we do here is to explicitly disable TLS for the routing service.
The problem we have if we don't explicitly disable TLS, is that we need
to specify a different value for "mode" depending on whether TLS is
enabled globally or not (ISTIO_MUTUAL or DISABLED)

This wouldn't be needed if we could set something like:

  trafficPolicy:
    tls:
      mode: INHERIT #this does not exist