### PR TITLE
fix: Add validation 2.x as fmp dependency.

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -100,6 +100,7 @@
                resources for both modules (which is what the aggregate profile above does)
             -->
             <dependencies>
+
               <dependency>
                 <groupId>io.openshift.booster</groupId>
                 <artifactId>spring-boot-istio-routing-service-a</artifactId>
@@ -114,6 +115,18 @@
                 <groupId>io.openshift.booster</groupId>
                 <artifactId>spring-boot-istio-routing-client</artifactId>
                 <version>${project.version}</version>
+              </dependency>
+
+              <!--
+                FMP transitively inherits validation-api 1.x from kubernetes-model
+                The rest of the project is using validation 2.x (e.g. hibernate-validator) via dependency management.
+                Since fmp has its own classloader it doesn't seem to be affected by dependency management.
+                And so we have a conflict. The conflict can be addressed by explicitly adding the validation 2.x to fmp.
+              -->
+              <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>2.0.1.Final</version>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
This is a fix for: https://issues.jboss.org/browse/SB-1222?filter=-1
